### PR TITLE
Add image search endpoints

### DIFF
--- a/app/api/search.py
+++ b/app/api/search.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter, status
+from typing import Annotated, List
+
+from fastapi import APIRouter, File, Form, status
 
 import app.schemas as schemas
 from config.globals import MODELS
@@ -24,3 +26,32 @@ async def search_description(
 ) -> list[schemas.Product]:
     """Search for products by using a description."""
     return await _search(request=request)
+
+
+@router.post(
+    "/image-url",
+    status_code=status.HTTP_200_OK,
+    response_model=list[schemas.Product],
+)
+async def search_image_url(
+    request: schemas.SearchByImageUrl,
+) -> list[schemas.Product]:
+    """Search for products by using an image URL."""
+    result = await MODELS["search"].search_by_image_url(input=request)
+    return result.products
+
+
+@router.post(
+    "/image",
+    status_code=status.HTTP_200_OK,
+    response_model=list[schemas.Product],
+)
+async def search_image(
+    image: Annotated[bytes, File(..., description="Image file")],
+    top_k: Annotated[int, Form(25)] = 25,
+    followed_stores: Annotated[List[int] | None, Form(None)] = None,
+) -> list[schemas.Product]:
+    """Search for products by uploading an image."""
+    request = schemas.SearchByImage(top_k=top_k, followed_stores=followed_stores)
+    result = await MODELS["search"].search_by_image(input=request, image_bytes=image)
+    return result.products

--- a/app/api/search.py
+++ b/app/api/search.py
@@ -48,8 +48,8 @@ async def search_image_url(
 )
 async def search_image(
     image: Annotated[bytes, File(..., description="Image file")],
-    top_k: Annotated[int, Form(25)] = 25,
-    followed_stores: Annotated[List[int] | None, Form(None)] = None,
+    top_k: Annotated[int, Form()] = 25,
+    followed_stores: Annotated[List[int] | None, Form()] = [],
 ) -> list[schemas.Product]:
     """Search for products by uploading an image."""
     request = schemas.SearchByImage(top_k=top_k, followed_stores=followed_stores)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -19,6 +19,24 @@ class SearchByDescription(SearchRequest):
     )
 
 
+class SearchByImageUrl(SearchRequest):
+    url: str = Field(
+        description="URL that points directly to an image.",
+    )
+    followed_stores: List[int] = Field(
+        default=None, description="Followd client stores"
+    )
+
+
+class SearchByImage(SearchRequest):
+    image: bytes | None = Field(
+        default=None, description="Binary image content (for documentation only)"
+    )
+    followed_stores: List[int] = Field(
+        default=None, description="Followd client stores"
+    )
+
+
 class Product(BaseModel):
     id: str | int = Field(description="Product ID", examples=["1234", 5678])
     similarity_score: Optional[float] = Field(

--- a/app/services/search.py
+++ b/app/services/search.py
@@ -1,7 +1,17 @@
+from io import BytesIO
+
+import requests
 import torch
+from PIL import Image
 from transformers import CLIPModel, CLIPProcessor
 
-from app.schemas import Product, SearchByDescription, SearchResponse
+from app.schemas import (
+    Product,
+    SearchByDescription,
+    SearchByImage,
+    SearchByImageUrl,
+    SearchResponse,
+)
 from config import settings
 from infrastructure.dependencies import get_vector_db_client
 
@@ -27,13 +37,24 @@ class SearchService:
             .tolist()
         )
 
-    async def search(self, input: SearchByDescription) -> SearchResponse:
-        text_embedding = await self.generate_text_embedding(input.text)
+    async def generate_image_embedding(self, image: Image.Image):
+        inputs = self.processor(images=image, return_tensors="pt")
+        with torch.no_grad():
+            image_features = self.model.get_image_features(**inputs)
+        return (
+            (image_features / image_features.norm(p=2, dim=-1, keepdim=True))
+            .numpy()
+            .flatten()
+            .tolist()
+        )
 
+    async def _search_with_embedding(
+        self, embedding: list[float], top_k: int, followed_stores: list[int] | None
+    ) -> SearchResponse:
         search_result = self.client.search(
-            query_vector=text_embedding,
-            limit=input.top_k,
-            followed_stores=input.followed_stores,
+            query_vector=embedding,
+            limit=top_k,
+            followed_stores=followed_stores,
         )
 
         products = []
@@ -43,3 +64,27 @@ class SearchService:
             products.append(product)
 
         return SearchResponse(products=products)
+
+    async def search(self, input: SearchByDescription) -> SearchResponse:
+        text_embedding = await self.generate_text_embedding(input.text)
+        return await self._search_with_embedding(
+            text_embedding, input.top_k, input.followed_stores
+        )
+
+    async def search_by_image(
+        self, input: SearchByImage, image_bytes: bytes
+    ) -> SearchResponse:
+        image = Image.open(BytesIO(image_bytes)).convert("RGB")
+        image_embedding = await self.generate_image_embedding(image)
+        return await self._search_with_embedding(
+            image_embedding, input.top_k, input.followed_stores
+        )
+
+    async def search_by_image_url(self, input: SearchByImageUrl) -> SearchResponse:
+        response = requests.get(input.url.strip(), timeout=10)
+        response.raise_for_status()
+        image = Image.open(BytesIO(response.content)).convert("RGB")
+        image_embedding = await self.generate_image_embedding(image)
+        return await self._search_with_embedding(
+            image_embedding, input.top_k, input.followed_stores
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "pydantic",
     "pydantic-settings",
     "psycopg2-binary",
+    "python-multipart",
 ]
 
 [project.optional-dependencies]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -255,6 +255,8 @@ python-dotenv==1.1.1
     # via
     #   search (pyproject.toml)
     #   pydantic-settings
+python-multipart==0.0.20
+    # via search (pyproject.toml)
 pytz==2025.2
     # via pandas
 pyyaml==6.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -210,6 +210,8 @@ python-dotenv==1.1.1
     # via
     #   search (pyproject.toml)
     #   pydantic-settings
+python-multipart==0.0.20
+    # via search (pyproject.toml)
 pytz==2025.2
     # via pandas
 pyyaml==6.0.2


### PR DESCRIPTION
## Summary
- expand schemas for image queries
- enable searching by uploaded image or image URL
- add service methods to embed and search via images

## Testing
- `pre-commit run --files app/schemas.py app/services/search.py app/api/search.py`
- `pytest -q` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6887c8d4426c832e8ca5b7826754756c